### PR TITLE
Using a variable for ng-show-auth would fail

### DIFF
--- a/app/js/module.waitForAuth.js
+++ b/app/js/module.waitForAuth.js
@@ -75,9 +75,11 @@ angular.module('waitForAuth', [])
       }
       return {
          restrict: 'A',
-         compile: function(el, attr) {
-            assertValidState(attr.ngShowAuth);
-            var expState = (attr.ngShowAuth||'').split(',');
+         link: function(scope, el, attr) {
+            var showAuth = scope.$eval(attr.ngShowAuth);
+            if (showAuth == null) { showAuth = attr.ngShowAuth; }
+            assertValidState(showAuth);
+            var expState = (showAuth||'').split(',');
             function fn(newState) {
                loginState = newState;
                var hide = !inList(newState, expState);


### PR DESCRIPTION
`ng-show-auth` was always expecting the value to be a string, this causes
problems if you want to dynamically build some items using, say, an `ng-repeat`.
Replaced the compile with a link (saw no explicit reason for the compile over
link in this function) and attempt to evaluate the value of the `ng-show-auth`
attribute. If this evaluates to undefined, we fall back to just using it as a
string, thus not breaking previous code using this method.

Alternatively a breaking change could be done by not allowing the fallback, but
instead requiring explicit strings as the attribute, such as:
`<a href="#/secret" ng-show-auth="'login'">Not For Your Eyes</a>`
