### PR TITLE
Remove guard operator to add consistency

### DIFF
--- a/app/js/service.login.js
+++ b/app/js/service.login.js
@@ -49,7 +49,12 @@ angular.module('myApp.service.login', ['firebase', 'myApp.service.firebase'])
 
             createAccount: function(email, pass, callback) {
                assertAuth();
-               auth.$createUser(email, pass).then(function(user) { callback && callback(null, user) }, callback);
+               auth.$createUser(email, pass)
+                 .then(function(user) { 
+                     if( callback ){
+                        callback(null, user);  
+                     }
+                  }, callback);
             },
 
             createProfile: profileCreator


### PR DESCRIPTION
In the login method 'callback' is checked for truthyness with an if statement, in the createAccount method 'callback' is checked for truthyness using a guard operator. I replaced the guard operator in createAccount with an if statement to add consistency.
