### PR TITLE
Changing angularfire-seed to angular-seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ including:
 ## How to use angularfire-seed
 
 Other than one additional configuration step (specifying your Firebase URL), this setup is nearly
-identical to angularfire-seed.
+identical to angular-seed.
 
 ### Prerequisites
 


### PR DESCRIPTION
I think you meant to say `this setup is nearly identical to angular-seed` and not `this setup is nearly identical to angularfire-seed`
