### PR TITLE
Corrected the adress of angular-seed in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # angularfire-seed — the seed for Angular+Firebase apps
 
-This derivative of [angular-seed](https://github.com/angular/angularfire-seed) is an application 
+This derivative of [angular-seed](https://github.com/angular/angular-seed) is an application 
 skeleton for a typical [AngularFire](http://angularfire.com/) web app. You can use it to quickly 
 bootstrap your Angular + Firebase projects.
 


### PR DESCRIPTION
The angular-seed project hyperlink was pointing to the angularfire-seed github page. I replace the older link ("https://github.com/angular/angularfire-seed") with "https://github.com/angular/angular-seed"
