### PR TITLE
no need to call firebase-simple-login.js

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -33,7 +33,6 @@
   <script src="bower_components/angular/angular.js"></script>
   <script src="bower_components/angular-route/angular-route.js"></script>
   <script src="bower_components/firebase/firebase.js"></script>
-  <script src="bower_components/firebase-simple-login/firebase-simple-login.js"></script>
   <script src="bower_components/angularfire/dist/angularfire.js"></script>
 
 


### PR DESCRIPTION
firebase-simple-login.js is not in the bower.json anymore because it is not needed with the new version of angularfire and firebase but it was still called in index.html. I removed it.
