### PR TITLE
bugfix: whenAuthenticated method now supports chaining

### DIFF
--- a/app/components/security/security.js
+++ b/app/components/security/security.js
@@ -33,6 +33,7 @@
           return Auth.$requireAuth();
         }];
         $routeProvider.when(path, route);
+        return this;
       }
     }])
 


### PR DESCRIPTION
Previously, any routeProvider configured with more than one route would fail if subsequent routes followed a .whenAuthenticated({ ... });

Example:

```
// This works fine

(function (angular) {

  'use strict';

  angular.module('myApp.task')

  .config(['$routeProvider', function($routeProvider) {

    $routeProvider

    .whenAuthenticated('/foo', {
      controller: 'fooController',
      templateUrl: 'foo.html',
      resolve: {
        user: ['Auth', function (Auth) {
          return Auth.$waitForAuth();
        }]
      }
    })

  }]);

})(angular);

// This fails

(function (angular) {

  'use strict';

  angular.module('myApp.task')

  .config(['$routeProvider', function($routeProvider) {

    $routeProvider

    .whenAuthenticated('/foo', {
      controller: 'fooController',
      templateUrl: 'foo.html',
      resolve: {
        user: ['Auth', function (Auth) {
          return Auth.$waitForAuth();
        }]
      }
    })

    .when('/foo/:id', {
      controller: 'fooController',
      templateUrl: 'foo.html'
      }
    })

  }]);

})(angular);

// This works

(function (angular) {

  'use strict';

  angular.module('myApp.task')

  .config(['$routeProvider', function($routeProvider) {

    $routeProvider

    .when('/foo/:id', {
      controller: 'fooController',
      templateUrl: 'foo.html'
      }
    })

    .whenAuthenticated('/foo', {
      controller: 'fooController',
      templateUrl: 'foo.html',
      resolve: {
        user: ['Auth', function (Auth) {
          return Auth.$waitForAuth();
        }]
      }
    })

  }]);

})(angular);
```

Let me know what you think!
